### PR TITLE
Update main.css

### DIFF
--- a/CSS/main.css
+++ b/CSS/main.css
@@ -10,19 +10,6 @@ body {
   overflow: hidden;
 }
 
-body:fullscreen {
-  background-color: #111;
-}
-body:-moz-full-screen {
-  background-color: #111;
-}
-body:-ms-fullscreen {
-  background-color: #111;
-}
-body:-webkit-full-screen {
-  background-color: #111;
-}
-
 p  {
   margin: 0;
 }
@@ -125,7 +112,7 @@ video {
 
 #closemenubutton {
   color: black;
-  text-shadow: unset;
+  text-shadow: inherit;
 }
 
 #site-menu {


### PR DESCRIPTION
removed body:fullscreen stuff because we fixed that issue in main.js
changed #closemenubutton.text-shadow:unset to #closemenubutton.text-shadow:inherit so it works in Edge
